### PR TITLE
Adding dependency to msgpack_rails gem to fix Data/Time serialization

### DIFF
--- a/lib/rpush/redis/version.rb
+++ b/lib/rpush/redis/version.rb
@@ -1,5 +1,5 @@
 module Rpush
   module Redis
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end

--- a/rpush-redis.gemspec
+++ b/rpush-redis.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "modis", "~> 1.4", ">= 1.4.1"
+  spec.add_dependency "msgpack_rails", "~> 0.4", ">= 0.4.2"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Using Rpush with Redis, dates and datetimes serialization crashes.

Examples:

``` ruby
irb> DateTime.now.to_msgpack
NoMethodError: undefined method `to_msgpack' for Tue, 03 Nov 2015 11:45:11 +0100:DateTime
irb> Date.today.to_msgpack
NoMethodError: undefined method `to_msgpack' for Tue, 03 Nov 2015:Date
```

For example, it happens when you try to include a date/time in the :data hash param of Rpush Notification.
