### PR TITLE
Update modis for Rails 5.2 support

### DIFF
--- a/rpush-redis.gemspec
+++ b/rpush-redis.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "modis", "~> 2.0"
+  spec.add_dependency "modis", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
@aried3r - See https://github.com/ileitch/modis/pull/19 for modis's upgrade to support Rails 5.2 . 