### PR TITLE
Relax modis dependency to allow for 3.x and 4.x versions

### DIFF
--- a/rpush-redis.gemspec
+++ b/rpush-redis.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "modis", "~> 3.0"
+  spec.add_dependency "modis", [">= 3.0", "< 5.0"]
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Hi again Rpush team 🙂

In order to allow for the recent Modis `4.0.0` release to be used with Rpush we also need this change.

AFAICT from the source code, `rpush-redis` gem only serves as the "link" that adds `modis` as a dependency into projects. This means that, we could in theory remove `rpush-redis` and manually add `modis` to our project's Gemfile and everything will work as expected. This way we can use Modis with version `4.0.0` (already tested it locally).

However, relaxing `rpush-redis` dependency like this will allow us to follow the "recommended way" of working with Rpush+Redis ([which is to add both `rpush` and `rpush-redis`](https://github.com/rpush/rpush/wiki/Using-Redis)).

I'm not sure if __(a)__ this is the way you would prefer the dependency to be bumped/relaxed, or __(b)__ if this will require a minor or major bump to `rpush-redis` (that's up to your best judgment). I personally like this approach because a minor bump release of `rpush-redis` would continue to work with Modis `3.x` while also allowing projects to bump up to `4.x`. An alternative could be to change the dependency to `~> 4.0`.